### PR TITLE
ReadTheDocs configuration and GitHub Actions pin updates

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@9f54435e0e72c53962ee863144e47a4b094bfd35 # v2.3.0
         with:
           channels: conda-forge,nodefaults
           channel-priority: strict
@@ -30,7 +30,7 @@ jobs:
           cd raijin
           make -j4 html
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3.8.0
+        uses: peaceiris/actions-gh-pages@068dc23d9710f1ba62e86896f84735d869951305 # v3.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./raijin/_build/html

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,6 +7,8 @@ version: 2
 
 build:
   os: 'ubuntu-20.04'
+  tools:
+    python: 'mambaforge-latest'
 
 sphinx:
   configuration: raijin/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@
 version: 2
 
 build:
-  image: latest
+  os: 'ubuntu-20.04'
 
 sphinx:
   configuration: raijin/conf.py

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -2,7 +2,7 @@ name: raijin
 channels:
   - conda-forge
 dependencies:
-  - python
+  - python<3.13 # imghdr removed in Python 3.13
   - myst-nb
   - pre-commit
   - sphinx


### PR DESCRIPTION
Pins third-party GitHub Actions to commit hash per updated guidance and updates the ReadTheDocs configuration and overall environment specification so that the site builds.